### PR TITLE
requirements update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@
 Django==1.4.22
 psycopg2==2.5.3
 PIL==1.1.7
--e git+git://github.com/matplotlib/matplotlib.git#egg=matplotlib
+matplotlib==1.4.3
 pygeoip==0.2.4
 django-auth-ldap==1.1.3
 ipaddr==2.1.10


### PR DESCRIPTION
Because of matplotlib 1.5.0 release https://github.com/matplotlib/matplotlib/releases/tag/v1.5.0 we no longer can install from git. It is caused by https://github.com/matplotlib/matplotlib/pull/5295

 This fixes the issue described in https://trello.com/c/S1o12nkO/1397-matplotlib-on-ome-web-staging
